### PR TITLE
feat: support changing the x264 encoder tune

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ For instance if you plan on streaming to Twitch, set the OUTPUT to something lik
 `OUTPUT` is the output file/stream. Can either start with `rtmp://`, `gs://` or end with `.mp4`. Defaults to `output.mp4`  
 `RATE` is the constant bitrate (CBR) used for the video. Defaults to `6000`  
 `RESOLUTION` is the resolution of the video. Defaults to `1280x720`  
+`TUNE` is the FFmpeg libx264 [tune setting](https://trac.ffmpeg.org/wiki/Encode/H.264#Tune). Defaults to `zerolatency`  
 `URL` is the webpage to record. Required.
 
 # Contributing

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { durationToFFmpegParams } from './ffmpeg'
 const disableAudio = process.env.DISABLE_AUDIO === 'true'
 const fps = process.env.FPS || 30
 const rate = process.env.RATE || 6000
+const tune = process.env.TUNE || 'zerolatency'
 const resolution = process.env.RESOLUTION
 const url = process.env.URL
 
@@ -80,7 +81,7 @@ async function main() {
     `ffmpeg -y -loglevel error -hide_banner -async 1 -nostdin -s ${resolution} -r ${fps} -draw_mouse 0
     -f x11grab -i $DISPLAY
     -f pulse -ac 2 -i default
-    -c:v libx264 -preset veryfast -tune zerolatency -b:v ${rate}k -minrate ${rate}k -maxrate ${rate}k -g 30
+    -c:v libx264 -preset veryfast -tune ${tune} -b:v ${rate}k -minrate ${rate}k -maxrate ${rate}k -g 30
     ${audioConfig}
     -ss 00:00:03 ${ffmpegDurationParams} -pix_fmt yuv420p ${exporter.getFFmpegOutputParams()}`.replaceAll(
       /[\n\r\s]+/gm,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ import { durationToFFmpegParams } from './ffmpeg'
 const disableAudio = process.env.DISABLE_AUDIO === 'true'
 const fps = process.env.FPS || 30
 const rate = process.env.RATE || 6000
-const tune = process.env.TUNE || 'zerolatency'
 const resolution = process.env.RESOLUTION
+const tune = process.env.TUNE || 'zerolatency'
 const url = process.env.URL
 
 async function main() {


### PR DESCRIPTION
This addresses https://github.com/digiz3d/docker-web-recorder/issues/109 by adding a TUNE environment variable to tweak the x264 encoder

It does not change the default (`zerolatency`) tune, to prevent the existing users from having potentially degraded visuals (depending on the use case)